### PR TITLE
Adding Dockerfile for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM bign8/static:latest
+ADD / /data/

--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ SVGs designed by [keygx](https://github.com/keygx) and licensed under the Creati
 [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/)
 
 This code is licensed under (TODO: figure out this license)
+
+
+## Docker Development
+
+For local development, the serving logic has been encapsulated in a dockerfile.
+
+```sh
+docker build -t bign8/gopher .
+docker run -it --rm -p 8080:8080 bign8/gopher .
+curl localhost:8080
+```


### PR DESCRIPTION
For local development, the serving logic has been encapsulated in a dockerfile.
```sh
docker build -t bign8/gopher .
docker run -it --rm -p 8080:8080 bign8/gopher .
open localhost:8080
```